### PR TITLE
Sorted apps, and user apps

### DIFF
--- a/pkgs/saturn/default.nix
+++ b/pkgs/saturn/default.nix
@@ -44,6 +44,7 @@ let fennel = fetchurl {
       lgi
       luafilesystem
       luaposix
+      penlight
       readline
     ]);
 in stdenv.mkDerivation {

--- a/pkgs/saturn/main.fnl
+++ b/pkgs/saturn/main.fnl
@@ -156,6 +156,7 @@
         vals (. parsed "Desktop Entry")]
     (when vals.Icon
       (tset vals "IconImage" (find-icon vals.Icon)))
+    (tset vals "ID" (f:sub 0 -9))
     vals))
 
 (fn current-user-home []


### PR DESCRIPTION
This PR changes more things in meat of the launcher.

I'm open to discussion about the implementation. Though I know the results are the right ones.

At a high level, this:

 - Adds the user's own `.desktop` files to the list (e.g. "apps" added by chrome)
 - Handles overrides by "ID" (desktop file filename)
 - Sorts apps by name

This has been done through penlight, as *when using Lua*, this is the first thing I would look at for tooling around Lists and such things. But I'm open to your opinions about any other way to solve the issues. I don't know if there's more idiomatic ways to approach fixing this in Fennel.

Please look at the commit messages, I *believe* they should explain the changes in finer grained details.